### PR TITLE
Replace spaces in filename placeholder with underscores

### DIFF
--- a/nonadmin.cmd
+++ b/nonadmin.cmd
@@ -1,1 +1,1 @@
-cmd /min /C "set __COMPAT_LAYER=RUNASINVOKER && start "" "[insert program filename]""
+cmd /min /C "set __COMPAT_LAYER=RUNASINVOKER && start "" "[insert_program_ filename]""


### PR DESCRIPTION
Replaced spaces in filename placeholder with underscores to avoid confusion